### PR TITLE
Use methodName() to eliminate method not found warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,7 @@
     },
     "require": {
         "covergenius/php-vcr": "^1.7",
-        "php": "^8.1"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^10.1"
+        "php": "^8.1",
+        "phpunit/phpunit": "^10.4"
     }
 }

--- a/src/Subscribers/OnTestPrepared.php
+++ b/src/Subscribers/OnTestPrepared.php
@@ -43,7 +43,11 @@ class OnTestPrepared implements Event\Test\PreparedSubscriber
     {
         $reflection = new \ReflectionClass($test);
         $class = $reflection->getProperty('className')->getValue($test);
-        $method = $test->name();
+        if ($test instanceof Event\Code\TestMethod) {
+            $method = $test->methodName();
+        } else {
+            $method = $test->name();
+        }
 
         $reflection = new \ReflectionMethod($class, $method);
         $docblock = $reflection->getDocComment();


### PR DESCRIPTION
From PHPUnit 10.4.0, PHPUnit throws exceptions from third-party subscribers.
https://github.com/sebastianbergmann/phpunit/commit/6ce7c0b02073ed9662bffe1b055d2f7d824e2640

When a test method uses Data Provider, the `$this->name()` in `\VCR\PHPUnit\TestListener\Subscribers\OnTestPrepared::getCassette()` returns method name + "with data set #0" resulting in the warning below. 

1) Exception in third-party event subscriber: Method Tests\VCR\PHPUnit\TestListener\VCRTestListenerTest::testInterceptsWithAnnotationsWhenUsingDataProvider with data set #0() does not exist

This PR is to pull the method name from `\PHPUnit\Event\Code\TestMethod::methodName()`.