### PR TITLE
Switch back to main php-vcr repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "covergenius/phpunit-testlistener-vcr",
+    "name": "oranges13/phpunit-testlistener-vcr",
     "description": "Integrates PHPUnit with PHP-VCR.",
     "license": "MIT",
     "authors": [
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "covergenius/php-vcr": "^1.7",
+        "php-vcr/php-vcr": "^1.7",
         "php": "^8.1",
         "phpunit/phpunit": "^10.4 | ^11"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "oranges13/phpunit-testlistener-vcr",
+    "name": "covergenius/phpunit-testlistener-vcr",
     "description": "Integrates PHPUnit with PHP-VCR.",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
The main php-vcr repo has been updated recently, and your fork of covergenius/php-vcr has not. Using other tools, such as allejo/php-vcr-sanitizer bring in both copies as a dependency which causes conflicts.