### PR TITLE
Allow to specify file via Vcr attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Use `@vcr cassette_name` on your tests to turn VCR automatically on and off.
 ``` php
 
 use PHPUnit\Framework\TestCase;
+use VCR\PHPUnit\TestListener\Attributes\Vcr;
 
 class VCRTest extends TestCase
 {
@@ -29,6 +30,14 @@ class VCRTest extends TestCase
         // Content of tests/fixtures/unittest_annotation_test: "This is a annotation test dummy".
         $result = file_get_contents('http://google.com');
         $this->assertEquals('This is a annotation test dummy.', $result, 'Call was not intercepted (using annotations).');
+    }
+
+    #[Vcr('unittest_annotation_test')]
+    public function testInterceptsWithAttributes(): void
+    {
+        // Content of tests/fixtures/unittest_annotation_test: "This is a annotation test dummy".
+        $result = file_get_contents('http://google.com');
+        $this->assertEquals('This is a annotation test dummy.', $result, 'Call was not intercepted (using attributes).');
     }
 }
 ```

--- a/src/Attributes/Vcr.php
+++ b/src/Attributes/Vcr.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace VCR\PHPUnit\TestListener\Attributes;
+
+use Attribute;
+
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Vcr
+{
+    /**
+     * @var non-empty-string
+     */
+    private string $cassette;
+
+    /**
+     * @param non-empty-string $cassette
+     */
+    public function __construct(string $cassette)
+    {
+        $this->cassette = $cassette;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function cassette(): string
+    {
+        return $this->cassette;
+    }
+}

--- a/tests/VCRTestListenerTest.php
+++ b/tests/VCRTestListenerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\VCR\PHPUnit\TestListener;
 
 use PHPUnit\Framework\TestCase;
+use VCR\PHPUnit\TestListener\Attributes\Vcr;
 
 final class VCRTestListenerTest extends TestCase
 {
@@ -46,6 +47,14 @@ final class VCRTestListenerTest extends TestCase
     public function testNoVcrAnnotationRunsSuccessfulAndDoesNotProduceWarnings()
     {
         $this->assertTrue(true, 'just adding an assertion here');
+    }
+
+    #[Vcr('unittest_annotation_test')]
+    public function testInterceptsWithAttributes(): void
+    {
+        // Content of tests/fixtures/unittest_annotation_test: "This is a annotation test dummy".
+        $result = file_get_contents('http://google.com');
+        $this->assertEquals('This is a annotation test dummy.', $result, 'Call was not intercepted (using attributes).');
     }
 
     /**


### PR DESCRIPTION
PHPUnit 11 has deprecated annotations that can be used in special PHP comments to add metadata to test classes and test methods in favour of attributes. While both are still supported, the listener will first check if the attribute is set (`#[Vcr('fixture/cassette.json')]`), and then check the annotations as a fallback (`/** @vcr fixture/cassette.json **/`).